### PR TITLE
feat: only use spend public key in subscriber

### DIFF
--- a/packages/mithras-subscriber/__test__/e2e.test.ts
+++ b/packages/mithras-subscriber/__test__/e2e.test.ts
@@ -55,7 +55,7 @@ describe("Mithras App", () => {
       algod: algorand.client.algod,
       appId: appClient.appId,
       discoveryKeypair: receiver.discoveryKeypair,
-      spendKeypair: receiver.spendKeypair,
+      spendPubkey: receiver.spendKeypair.publicKey,
     });
 
     await receiversSubscriber.subscriber.pollOnce();
@@ -96,7 +96,7 @@ describe("Mithras App", () => {
       algod: algorand.client.algod,
       appId: appClient.appId,
       discoveryKeypair: initialReceiver.discoveryKeypair,
-      spendKeypair: initialReceiver.spendKeypair,
+      spendPubkey: initialReceiver.spendKeypair.publicKey,
     });
 
     expect(subscriber.amount).toBe(0n);

--- a/packages/mithras-subscriber/src/index.ts
+++ b/packages/mithras-subscriber/src/index.ts
@@ -393,20 +393,6 @@ class BaseMithrasSubscriber {
           );
           continue;
         }
-        const nullifier = utxo.computeNullifier();
-        if (balanceState.utxos.has(nullifier)) {
-          console.debug(
-            `Nullifier ${nullifier} from transaction ${txn.id} already exists in balance state, skipping...`,
-          );
-          continue;
-        } else {
-          balanceState.utxos.set(nullifier, {
-            round: algosdk.encodeUint64(txn.confirmedRound ?? 0n),
-            amount: algosdk.encodeUint64(utxo.amount),
-            txid: new Uint8Array(base32.decode.asBytes(txn.id)),
-            firstCommitment,
-          });
-        }
 
         if (spendKeypair !== undefined) {
           const derivedSigner = StealthKeypair.derive(
@@ -426,6 +412,21 @@ class BaseMithrasSubscriber {
           console.debug(
             `No spend keypair provided, skipping stealth key verification for transaction ${txn.id}...`,
           );
+        }
+
+        const nullifier = utxo.computeNullifier();
+        if (balanceState.utxos.has(nullifier)) {
+          console.debug(
+            `Nullifier ${nullifier} from transaction ${txn.id} already exists in balance state, skipping...`,
+          );
+          continue;
+        } else {
+          balanceState.utxos.set(nullifier, {
+            round: algosdk.encodeUint64(txn.confirmedRound ?? 0n),
+            amount: algosdk.encodeUint64(utxo.amount),
+            txid: new Uint8Array(base32.decode.asBytes(txn.id)),
+            firstCommitment,
+          });
         }
 
         console.debug(`Adding amount ${utxo.amount} from tx ${txn.id}`);


### PR DESCRIPTION
Previously the private spend key was used to derive the stealth address, but this involved in needlessly passing the private key to the subscriber. We can do the same validation with just the public key. 