### PR TITLE
chore: rename discovery to view

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -19,7 +19,7 @@
 - **Sender:** Can compute $P'$ but not $s'$.
 - **Receiver:** Can compute $s'$ (and thus $P'$) from $s$ and $t$.
 
-### Discovery Keypair
+### View Keypair
 
 - **Type:** X25519 keypair
 - **Purpose:** Enables scanning to detect relevant outputs.
@@ -29,26 +29,26 @@
 
 ## Secrets
 
-### Discovery Secret
+### View Secret
 
 - **Type:** 32-byte shared secret from ECDH:
   - Sender: $T = r·D$
   - Receiver: $T = d·R$
 - **Purpose:** Input for:
   - Stealth scalar $t$ for spend key derivation.
-  - Key for computing the discovery tag.
+  - Key for computing the view tag.
 
-### Discovery Tag
+### View Tag
 
 - **Formula:**
 
   ```text
-  tag = SHA512_256("discovery-tag" || T || sender || fv || lv || lease)
+  tag = SHA512_256("view-tag" || T || sender || fv || lv || lease)
   ```
 
 - **Purpose:** Small value in tx header that lets receiver quickly identify their outputs.
 
-- **Privacy:** Outsiders can’t link tags without `discovery_secret`.
+- **Privacy:** Outsiders can’t link tags without `view_secret`.
 
 ### Spend Secret
 
@@ -63,15 +63,15 @@
 | ------------------------------- | ------ | -------- | ------------------------------- |
 | **Spend privkey** `s`           | No     | Yes      | No                              |
 | **Spend pubkey** `P`            | Yes    | Yes      | Possibly (externally published) |
-| **Discovery privkey** `d`       | No     | Yes      | No                              |
-| **Discovery pubkey** `D`        | Yes    | Yes      | Possibly (externally published) |
+| **View privkey** `d`            | No     | Yes      | No                              |
+| **View pubkey** `D`             | Yes    | Yes      | Possibly (externally published) |
 | **Ephemeral privkey** `r`       | Yes    | No       | No                              |
 | **Ephemeral pubkey** `R`        | Yes    | Yes      | Yes (in tx)                     |
-| **Discovery secret** `T`        | Yes    | Yes      | No                              |
+| **View secret** `T`             | Yes    | Yes      | No                              |
 | **Stealth scalar** `t`          | Yes    | Yes      | No                              |
 | **One-time spend privkey** `s'` | No     | Yes      | No                              |
 | **One-time spend pubkey** `P'`  | Yes    | Yes      | Yes (locks UTXO)                |
-| **Discovery tag** `tag`         | Yes    | Yes      | Yes (in tx)                     |
+| **View tag** `tag`              | Yes    | Yes      | Yes (in tx)                     |
 | **Spend secret**                | Yes    | Yes      | No (encrypted in tx)            |
 
 ## Circuits

--- a/packages/mithras-contracts-and-circuits/__test__/mithras.test.ts
+++ b/packages/mithras-contracts-and-circuits/__test__/mithras.test.ts
@@ -11,7 +11,7 @@ import { MerkleTestHelpers, MimcCalculator } from "./utils/test-utils";
 import { Address } from "algosdk";
 import { depositVerifier, MithrasProtocolClient, spendVerifier } from "../src";
 import {
-  DiscoveryKeypair,
+  ViewKeypair,
   MithrasAddr,
   SpendKeypair,
   SupportedHpkeSuite,
@@ -65,7 +65,7 @@ describe("Mithras App", () => {
       1n,
       MithrasAddr.fromKeys(
         SpendKeypair.generate().publicKey,
-        DiscoveryKeypair.generate().publicKey,
+        ViewKeypair.generate().publicKey,
         1,
         0,
         SupportedHpkeSuite.x25519Sha256ChaCha20Poly1305,

--- a/packages/mithras-crypto/src/address.ts
+++ b/packages/mithras-crypto/src/address.ts
@@ -5,14 +5,14 @@ export class MithrasAddr {
   network: number;
   suite: number;
   spendEd25519: Uint8Array;
-  discX25519: Uint8Array;
+  viewX25519: Uint8Array;
 
   constructor(
     version: number,
     network: number,
     suite: number,
     spendEd25519: Uint8Array,
-    discX25519: Uint8Array,
+    viewX25519: Uint8Array,
   ) {
     this.version = version;
     this.network = network;
@@ -23,24 +23,24 @@ export class MithrasAddr {
         `invalid spendEd25519 length. Got ${spendEd25519.length}, expected 32`,
       );
     }
-    if (discX25519.length !== 32) {
+    if (viewX25519.length !== 32) {
       throw new Error(
-        `invalid discX25519 length. Got ${discX25519.length}, expected 32`,
+        `invalid viewX25519 length. Got ${viewX25519.length}, expected 32`,
       );
     }
 
     this.spendEd25519 = spendEd25519;
-    this.discX25519 = discX25519;
+    this.viewX25519 = viewX25519;
   }
 
   static fromKeys(
     spend: Uint8Array,
-    disc: Uint8Array,
+    view: Uint8Array,
     version: number,
     network: number,
     suite: number,
   ): MithrasAddr {
-    return new MithrasAddr(version, network, suite, spend, disc);
+    return new MithrasAddr(version, network, suite, spend, view);
   }
 
   encode(): string {
@@ -49,7 +49,7 @@ export class MithrasAddr {
     data[1] = this.network;
     data[2] = this.suite;
     data.set(this.spendEd25519, 3);
-    data.set(this.discX25519, 35);
+    data.set(this.viewX25519, 35);
 
     return bech32.encode("mith", bech32.toWords(data), 200);
   }
@@ -66,8 +66,8 @@ export class MithrasAddr {
     const network = data[1];
     const suite = data[2];
     const spend = data.slice(3, 35);
-    const disc = data.slice(35, 67);
+    const view = data.slice(35, 67);
 
-    return new MithrasAddr(version, network, suite, spend, disc);
+    return new MithrasAddr(version, network, suite, spend, view);
   }
 }

--- a/packages/mithras-crypto/src/index.ts
+++ b/packages/mithras-crypto/src/index.ts
@@ -1,6 +1,6 @@
 export * from "./hpke";
 export * from "./keypairs";
-export * from "./discovery";
+export * from "./view";
 export * from "./mimc";
 export * from "./address";
 export * from "./utxo";

--- a/packages/mithras-crypto/src/view.ts
+++ b/packages/mithras-crypto/src/view.ts
@@ -2,38 +2,32 @@ import { sha512_256 } from "@noble/hashes/sha2.js";
 import { x25519 } from "@noble/curves/ed25519.js";
 import { numberToBytesLE } from "@noble/curves/utils.js";
 
-export function computeDiscoverySecretSender(
+export function computeViewSecretSender(
   ephemeralPrivate: Uint8Array,
-  discoveryPublic: Uint8Array,
+  viewPublic: Uint8Array,
 ): Uint8Array {
-  const sharedSecret = x25519.getSharedSecret(
-    ephemeralPrivate,
-    discoveryPublic,
-  );
+  const sharedSecret = x25519.getSharedSecret(ephemeralPrivate, viewPublic);
   return sharedSecret;
 }
 
-export function computeDiscoverySecretReceiver(
-  discoveryPrivate: Uint8Array,
+export function computeViewSecretReceiver(
+  viewPrivate: Uint8Array,
   ephemeralPublic: Uint8Array,
 ): Uint8Array {
-  const sharedSecret = x25519.getSharedSecret(
-    discoveryPrivate,
-    ephemeralPublic,
-  );
+  const sharedSecret = x25519.getSharedSecret(viewPrivate, ephemeralPublic);
   return sharedSecret;
 }
 
-export function computeDiscoveryTag(
-  discoverySecret: Uint8Array,
+export function computeViewTag(
+  viewSecret: Uint8Array,
   sender: Uint8Array,
   fv: bigint,
   lv: bigint,
   lease: Uint8Array,
 ): Uint8Array {
   const hasher = sha512_256.create();
-  hasher.update(new TextEncoder().encode("discovery-tag"));
-  hasher.update(discoverySecret);
+  hasher.update(new TextEncoder().encode("view-tag"));
+  hasher.update(viewSecret);
   hasher.update(sender);
   hasher.update(numberToBytesLE(fv, 8));
   hasher.update(numberToBytesLE(lv, 8));

--- a/packages/mithras-subscriber/__test__/e2e.test.ts
+++ b/packages/mithras-subscriber/__test__/e2e.test.ts
@@ -19,13 +19,13 @@ describe("Mithras App", () => {
     amount: bigint,
   ) => {
     const utxo = spenderSubscriber.utxos.entries().next().value;
-    const spenderDisc = spender.discoveryKeypair;
+    const spenderView = spender.viewKeypair;
     const spenderKeypair = spender.spendKeypair;
 
     const { secrets, treeIndex } = await algodUtxoLookup(
       algorand.client.algod,
       utxo[1],
-      spenderDisc,
+      spenderView,
     );
 
     const receiver = MithrasAccount.generate();
@@ -54,7 +54,7 @@ describe("Mithras App", () => {
     const receiversSubscriber = await BalanceAndTreeSubscriber.fromAppId({
       algod: algorand.client.algod,
       appId: appClient.appId,
-      discoveryKeypair: receiver.discoveryKeypair,
+      viewKeypair: receiver.viewKeypair,
       spendPubkey: receiver.spendKeypair.publicKey,
     });
 
@@ -95,7 +95,7 @@ describe("Mithras App", () => {
     const subscriber = await BalanceAndTreeSubscriber.fromAppId({
       algod: algorand.client.algod,
       appId: appClient.appId,
-      discoveryKeypair: initialReceiver.discoveryKeypair,
+      viewKeypair: initialReceiver.viewKeypair,
       spendPubkey: initialReceiver.spendKeypair.publicKey,
     });
 
@@ -110,7 +110,7 @@ describe("Mithras App", () => {
     const { secrets } = await algodUtxoLookup(
       algorand.client.algod,
       utxo[1],
-      initialReceiver.discoveryKeypair,
+      initialReceiver.viewKeypair,
     );
 
     expect(secrets.amount).toBe(initialAmount);

--- a/packages/mithras-subscriber/__test__/e2e.test.ts
+++ b/packages/mithras-subscriber/__test__/e2e.test.ts
@@ -55,7 +55,7 @@ describe("Mithras App", () => {
       algod: algorand.client.algod,
       appId: appClient.appId,
       discoveryKeypair: receiver.discoveryKeypair,
-      spendKeypair: receiver.spendKeypair,
+      spendPubkey: receiver.spendKeypair.publicKey,
     });
 
     await receiversSubscriber.subscriber.pollOnce();
@@ -96,7 +96,7 @@ describe("Mithras App", () => {
       algod: algorand.client.algod,
       appId: appClient.appId,
       discoveryKeypair: initialReceiver.discoveryKeypair,
-      spendKeypair: initialReceiver.spendKeypair,
+      spendPubkey: initialReceiver.spendKeypair.publicKey,
     });
 
     expect(subscriber.amount).toBe(0n);

--- a/packages/mithras-subscriber/src/index.ts
+++ b/packages/mithras-subscriber/src/index.ts
@@ -329,7 +329,7 @@ class BaseMithrasSubscriber {
         spendPubkey === undefined
       ) {
         console.debug(
-          "No view or spend keypair provided, skipping transaction processing",
+          "View keypair or spend public key not provided, skipping balance update logic",
         );
         return;
       }

--- a/packages/mithras-subscriber/src/index.ts
+++ b/packages/mithras-subscriber/src/index.ts
@@ -7,12 +7,10 @@ import algosdk from "algosdk";
 import {
   DiscoveryKeypair,
   HpkeEnvelope,
-  MerkleProof as MerkleProof,
   MimcMerkleTree,
-  SpendKeypair,
   TransactionMetadata,
-  StealthKeypair,
   UtxoSecrets,
+  deriveStealthPubkey,
 } from "../../mithras-crypto/src";
 import base32 from "hi-base32";
 
@@ -187,7 +185,7 @@ export async function algodUtxoLookup(
 
 export type BalanceSubscriberConfig = {
   discoveryKeypair: DiscoveryKeypair;
-  spendKeypair?: SpendKeypair;
+  spendPubkey: Uint8Array;
 };
 
 export type MerkleTreeSubscriberConfig = {
@@ -224,7 +222,7 @@ type BaseSubscriberOptions = {
   appId: bigint;
   startRound: bigint;
   discoveryKeypair?: DiscoveryKeypair;
-  spendKeypair?: SpendKeypair;
+  spendPubkey?: Uint8Array;
   merkleTree?: MimcMerkleTree;
   balanceState?: BalanceState;
 };
@@ -278,7 +276,7 @@ class BaseMithrasSubscriber {
       appId,
       startRound,
       discoveryKeypair,
-      spendKeypair,
+      spendPubkey,
       merkleTree,
       balanceState,
     } = options;
@@ -328,7 +326,7 @@ class BaseMithrasSubscriber {
       if (
         balanceState === undefined ||
         discoveryKeypair === undefined ||
-        spendKeypair === undefined
+        spendPubkey === undefined
       ) {
         console.debug(
           "No discovery or spend keypair provided, skipping transaction processing",
@@ -394,24 +392,16 @@ class BaseMithrasSubscriber {
           continue;
         }
 
-        if (spendKeypair !== undefined) {
-          const derivedSigner = StealthKeypair.derive(
-            spendKeypair,
-            utxo.stealthScalar,
-          );
+        const derivedStealthPublicKey = deriveStealthPubkey(
+          spendPubkey,
+          utxo.stealthScalar,
+        );
 
-          if (
-            derivedSigner.publicKey.toString() != utxo.stealthPubkey.toString()
-          ) {
-            console.debug(
-              `Derived stealth public key does not match expected stealth public key for transaction ${txn.id}, skipping...`,
-            );
-            continue;
-          }
-        } else {
+        if (!equalBytes(derivedStealthPublicKey, utxo.stealthPubkey)) {
           console.debug(
-            `No spend keypair provided, skipping stealth key verification for transaction ${txn.id}...`,
+            `Derived stealth public key does not match expected stealth public key for transaction ${txn.id}, skipping...`,
           );
+          continue;
         }
 
         const nullifier = utxo.computeNullifier();
@@ -451,7 +441,7 @@ export class BalanceSubscriber extends BaseMithrasSubscriber {
       config.appId,
       startRound,
       config.discoveryKeypair,
-      config.spendKeypair,
+      config.spendPubkey,
     );
   }
 
@@ -460,7 +450,7 @@ export class BalanceSubscriber extends BaseMithrasSubscriber {
     appId: bigint,
     startRound: bigint,
     discoveryKeypair: DiscoveryKeypair,
-    spendKeypair?: SpendKeypair,
+    spendPubkey: Uint8Array,
   ) {
     const balanceState: BalanceState = {
       amount: 0n,
@@ -471,7 +461,7 @@ export class BalanceSubscriber extends BaseMithrasSubscriber {
       appId,
       startRound,
       discoveryKeypair,
-      spendKeypair,
+      spendPubkey: spendPubkey,
       balanceState,
     });
     this.balanceState = balanceState;
@@ -546,7 +536,7 @@ export class BalanceAndTreeSubscriber extends BaseMithrasSubscriber {
       startRound,
       config.discoveryKeypair,
       config.merkleTree ?? new MimcMerkleTree(),
-      config.spendKeypair,
+      config.spendPubkey,
     );
   }
 
@@ -556,7 +546,7 @@ export class BalanceAndTreeSubscriber extends BaseMithrasSubscriber {
     startRound: bigint,
     discoveryKeypair: DiscoveryKeypair,
     merkleTree: MimcMerkleTree,
-    spendKeypair?: SpendKeypair,
+    spendKeypair: Uint8Array,
   ) {
     const balanceState: BalanceState = {
       amount: 0n,
@@ -567,7 +557,7 @@ export class BalanceAndTreeSubscriber extends BaseMithrasSubscriber {
       appId,
       startRound,
       discoveryKeypair,
-      spendKeypair,
+      spendPubkey: spendKeypair,
       merkleTree,
       balanceState,
     });

--- a/packages/mithras-subscriber/src/index.ts
+++ b/packages/mithras-subscriber/src/index.ts
@@ -5,7 +5,7 @@ import {
 } from "@algorandfoundation/algokit-subscriber/types/subscription";
 import algosdk from "algosdk";
 import {
-  DiscoveryKeypair,
+  ViewKeypair,
   HpkeEnvelope,
   MimcMerkleTree,
   TransactionMetadata,
@@ -110,7 +110,7 @@ export type UtxoInfo = {
 export async function algodUtxoLookup(
   algod: algosdk.Algodv2,
   info: UtxoInfo,
-  discvoveryKeypair: DiscoveryKeypair,
+  viewKeypair: ViewKeypair,
 ): Promise<{ secrets: UtxoSecrets; treeIndex: number }> {
   const block = await algod.block(algosdk.decodeUint64(info.round)).do();
   const transaction = block.block.payset.find((t) => {
@@ -173,7 +173,7 @@ export async function algodUtxoLookup(
 
   const secrets = await UtxoSecrets.fromHpkeEnvelope(
     hpkeEnv,
-    discvoveryKeypair,
+    viewKeypair,
     txnMetadata,
   );
 
@@ -184,7 +184,7 @@ export async function algodUtxoLookup(
 }
 
 export type BalanceSubscriberConfig = {
-  discoveryKeypair: DiscoveryKeypair;
+  viewKeypair: ViewKeypair;
   spendPubkey: Uint8Array;
 };
 
@@ -221,7 +221,7 @@ type BaseSubscriberOptions = {
   algod: algosdk.Algodv2;
   appId: bigint;
   startRound: bigint;
-  discoveryKeypair?: DiscoveryKeypair;
+  viewKeypair?: ViewKeypair;
   spendPubkey?: Uint8Array;
   merkleTree?: MimcMerkleTree;
   balanceState?: BalanceState;
@@ -275,7 +275,7 @@ class BaseMithrasSubscriber {
       algod,
       appId,
       startRound,
-      discoveryKeypair,
+      viewKeypair,
       spendPubkey,
       merkleTree,
       balanceState,
@@ -325,11 +325,11 @@ class BaseMithrasSubscriber {
 
       if (
         balanceState === undefined ||
-        discoveryKeypair === undefined ||
+        viewKeypair === undefined ||
         spendPubkey === undefined
       ) {
         console.debug(
-          "No discovery or spend keypair provided, skipping transaction processing",
+          "No view or spend keypair provided, skipping transaction processing",
         );
         return;
       }
@@ -364,13 +364,11 @@ class BaseMithrasSubscriber {
         );
 
         console.debug(
-          `Performing discovery check for HPKE envelope in transaction ${txn.id}...`,
+          `Performing view check for HPKE envelope in transaction ${txn.id}...`,
         );
-        if (
-          !envelope.discoveryCheck(discoveryKeypair.privateKey, txnMetadata)
-        ) {
+        if (!envelope.viewCheck(viewKeypair.privateKey, txnMetadata)) {
           console.debug(
-            `HPKE envelope in transaction ${txn.id} failed discovery check, skipping...`,
+            `HPKE envelope in transaction ${txn.id} failed view check, skipping...`,
           );
           continue;
         }
@@ -378,7 +376,7 @@ class BaseMithrasSubscriber {
         console.debug(`Decrypting HPKE envelope for transaction ${txn.id}...`);
         const utxo = await UtxoSecrets.fromHpkeEnvelope(
           envelope,
-          discoveryKeypair,
+          viewKeypair,
           txnMetadata,
         );
 
@@ -440,7 +438,7 @@ export class BalanceSubscriber extends BaseMithrasSubscriber {
       config.algod,
       config.appId,
       startRound,
-      config.discoveryKeypair,
+      config.viewKeypair,
       config.spendPubkey,
     );
   }
@@ -449,7 +447,7 @@ export class BalanceSubscriber extends BaseMithrasSubscriber {
     algod: algosdk.Algodv2,
     appId: bigint,
     startRound: bigint,
-    discoveryKeypair: DiscoveryKeypair,
+    viewKeypair: ViewKeypair,
     spendPubkey: Uint8Array,
   ) {
     const balanceState: BalanceState = {
@@ -460,7 +458,7 @@ export class BalanceSubscriber extends BaseMithrasSubscriber {
       algod,
       appId,
       startRound,
-      discoveryKeypair,
+      viewKeypair,
       spendPubkey: spendPubkey,
       balanceState,
     });
@@ -534,7 +532,7 @@ export class BalanceAndTreeSubscriber extends BaseMithrasSubscriber {
       config.algod,
       config.appId,
       startRound,
-      config.discoveryKeypair,
+      config.viewKeypair,
       config.merkleTree ?? new MimcMerkleTree(),
       config.spendPubkey,
     );
@@ -544,9 +542,9 @@ export class BalanceAndTreeSubscriber extends BaseMithrasSubscriber {
     algod: algosdk.Algodv2,
     appId: bigint,
     startRound: bigint,
-    discoveryKeypair: DiscoveryKeypair,
+    viewKeypair: ViewKeypair,
     merkleTree: MimcMerkleTree,
-    spendKeypair: Uint8Array,
+    spendPubkey: Uint8Array,
   ) {
     const balanceState: BalanceState = {
       amount: 0n,
@@ -556,8 +554,8 @@ export class BalanceAndTreeSubscriber extends BaseMithrasSubscriber {
       algod,
       appId,
       startRound,
-      discoveryKeypair,
-      spendPubkey: spendKeypair,
+      viewKeypair,
+      spendPubkey,
       merkleTree,
       balanceState,
     });


### PR DESCRIPTION
This is mainly because view just seems like a better name and it aligns with other ecosystems (i.e. monero)